### PR TITLE
add tiktoken to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pinecone-client
 google-generativeai
 termcolor
 bs4
+tiktoken


### PR DESCRIPTION
When I run slashGPT, there was no tiktoken.

```
OPENAI_API_KEY=xxxxxxxxx ./SlashGPT.py 
Traceback (most recent call last):
  File "/Users/isamu/SlashGPT/./SlashGPT.py", line 11, in <module>
    import tiktoken  # for counting tokens
ModuleNotFoundError: No module named 'tiktoken'
```