### PR TITLE
extend help

### DIFF
--- a/SlashGPT.py
+++ b/SlashGPT.py
@@ -306,9 +306,15 @@ class Main:
             print(self.config.ONELINE_HELP)
         elif (question[0] == "/"):
             key = question[1:]
-            if (key == "help"):
-                list = ", ".join(f"/{key}" for key in self.manifests.keys())
-                print(f"Extensions: {list}")
+            commands = key.split(' ')
+            if (commands[0] == "help"):
+                if (len(commands) == 1):
+                    list = ", ".join(f"/{key}" for key in sorted(self.manifests.keys()))
+                    print(f"Extensions: {list}")
+                if (len(commands) == 2):
+                    manifest = self.manifests.get(commands[1])
+                    if (manifest):
+                       print(manifest)
             elif (key == "bye"):
                 self.exit = True;
             elif (key == "verbose"):


### PR DESCRIPTION
Made it possible to see the details of the manifest with the help command.

```
You: /help
Extensions: /accountant, /aiticker, /baby, /brand, /browser, /business, /cal, /career, /chef, /comedian, /cook, /crush, /currency, /definitive, /dentist, /dispatcher, /diy, /doctor, /doraemon, /drone, /drone2, /drone3, /english, /goku, /historian, /home, /home2, /hotel, /interview, /iyashi, /jobs, /journalist, /kame, /kanryo, /kayak, /linux, /lou-oshiba, /mag2, /math, /ml, /movie, /obachan, /obachan2, /olympic, /omochikaeri, /paper, /patent, /poet, /products, /python, /relationship, /shinjirou, /shirankedo, /socrates, /song, /sql, /story, /svg, /tools, /travel, /weather, /wolfram, /yoda, /yogi
You: /help yogi
{'title': 'Yogi', 'source': 'https://github.com/f/awesome-chatgpt-prompts', 'prompt': ['I want you to act as a yogi.', 'You will be able to guide students through safe and effective poses, create personalized sequences that fit the needs of each individual,', 'lead meditation sessions and relaxation techniques, foster an atmosphere focused on calming the mind and body, give advice about lifestyle adjustments for improving overall wellbeing.']}

```