### PR TITLE
Add Windows Support

### DIFF
--- a/SlashGPT.py
+++ b/SlashGPT.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import os
-import readline # So that input can handle Kanji & delete
+import platform
+if platform.system() == "Darwin":
+    import readline # So that input can handle Kanji & delete
 import openai
 from dotenv import load_dotenv
 import json
@@ -78,7 +80,7 @@ class ChatConfig:
         self.manifests = {}
         files = os.listdir(path)
         for file in files:
-            with open(f"{path}/{file}", 'r') as f:
+            with open(f"{path}/{file}", 'r',encoding="utf-8") as f:	# encoding add for Win
                 self.manifests[file.split('.')[0]] = json.load(f)
 
 """
@@ -566,7 +568,9 @@ class Main:
                             playsound("./output/audio.mp3")
 
                         self.context.appendMessage(role, res)
-                        with open(f"output/{self.context.key}/{self.context.time}.json", 'w') as f:
+# Windows patch
+                        timeStr = self.context.time.strftime("%Y-%m-%d %H-%M-%S.%f")
+                        with open(f'output/{self.context.key}/{timeStr}.json', 'w') as f:   
                             json.dump(self.context.messages, f)
 
                     if function_call:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ bs4
 tiktoken
 gTTS
 playsound
-pyobjc
+pyobjc; sys_platform == 'darwin' 
 IPython
 matplotlib
 numpy


### PR DESCRIPTION
1. Conditionally excluding library used only on Mac from requriemets.txt  (pyobjc; sys_platform == 'darwin' 
)
2.Conditionally excluding reading library used only on Mac from slashtpt.py
import platform
if platform.system() == "Darwin":
    import readline # So that input can handle Kanji & delete

3. set encoding when reading Manifest file
4. get rid of ':' from Manifest file name

This is my first PR, so it may concude some mistakes.
I don't test this in Mac environment.
 