### PR TITLE
Adding Anthropic + simplifying model calling across Palm, Replicate, OpenAI

### DIFF
--- a/SlashGPT.py
+++ b/SlashGPT.py
@@ -318,6 +318,12 @@ class ChatSession:
             response = completion(mode=replicate_model, messages=self.messages, temperature=self.temperature)
             (function_call, res) = self._extractFunctionCall(''.join(response[0].message.content))
 
+        elif self.model == "claude":
+            if self.functions:
+                self.messages[{"content": f"system: Here is the definition of functions available to you to call.\n{self.functions}\nYou need to generate a json file with 'name' for function name and 'arguments' for argument.assistant:"}]
+            response = completion(mode="claude-instant-1", messages=self.messages)
+            (function_call, res) = self._extractFunctionCall(''.join(response[0].message.content))
+            
         else:
             if self.functions:
                 response = completion(


### PR DESCRIPTION
Hi @snakajima, 

Noticed you're using a couple different llm providers in `generateResponse`. I'm working on `litellm` (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful. 

Simplified your model calling and added support for anthropic-claude models. 

Would love to know if this helps. Also adding a screenshot of the code working post changes. 

<img width="536" alt="Screenshot 2023-08-02 at 1 53 41 PM" src="https://github.com/snakajima/SlashGPT/assets/17561003/19370a67-521c-4060-ae53-a74dd112dcfa">