### PR TITLE
fix palm function call

### DIFF
--- a/src/slashgpt/llms/engine/palm.py
+++ b/src/slashgpt/llms/engine/palm.py
@@ -39,6 +39,7 @@ class LLMEnginePaLM(LLMEngineBase):
 
         response = palm.chat(**defaults, context=system, examples=[], messages=new_messages)
         res = response.last
+        function_call = None
         if res:
             if verbose:
                 print_error(res)


### PR DESCRIPTION

I found an error when running the sample after autotest

[{'reason': <BlockedReason.OTHER: 2>}]
Exception: Restarting the chat :local variable 'function_call' referenced before assignment
