### PR TITLE
fix test: rename jupyter to code

### DIFF
--- a/test/default.json
+++ b/test/default.json
@@ -13,7 +13,7 @@
     "agent": "cal",
     "message": "/sample"
   },{
-    "agent": "jupyter",
+    "agent": "code",
     "message": "/sample_stock"
   },{
     "agent": "dispatcher",


### PR DESCRIPTION
Jupyter in the manifest has been changed to code.
However, the test name has not changed.