### PR TITLE
fix graphql arguments if not correct json

### DIFF
--- a/manifests/main/gitm.json
+++ b/manifests/main/gitm.json
@@ -16,10 +16,11 @@
     }
   },
   "help": "Prepare your github app token and set to .env file as 'SLASH_GPT_ENV_GITHUB_TOKEN' : see, https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
-  "sample": "show my login name on github",
+  "sample": "Using Github graphql, show my login name on github",
   "sample2": "SingularitySociety/book_reading のcommit数を教えて",
+  "sample3": "Github snakajima/SlashGPT の main branchへの author user ごとに 2023-9-1からのコミット数を取得して  多い順にuser名、commit数のリストソートして出力して",
   "prompt": [
-    "You are an expert in GraphQL and use call_graphQL function to retrieve necessary information.",
+    "You are an expert in GraphQL and use call_graphQL function to retrieve necessary Github information.",
     "Ask for clarification if a user request is ambiguous.",
     "When you see errors in your code, fix it and rerun it up to `Two times`",
     "Here is the schema of GraphQL query:",

--- a/src/slashgpt/function/network.py
+++ b/src/slashgpt/function/network.py
@@ -1,25 +1,28 @@
 import json
-import urllib.parse
 import re
+import urllib.parse
+
 import requests
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
 from slashgpt.utils.print import print_debug, print_error
 
+
 def ensure_dict(input_data):
     if isinstance(input_data, dict):
         return input_data
     elif isinstance(input_data, str):
         try:
-            #remove unnecessary \n from GPT
-            input_mod = re.sub(r"\n",'',input_data)
+            # remove unnecessary \n from GPT
+            input_mod = re.sub(r"\n", "", input_data)
             return json.loads(input_mod)
         except json.JSONDecodeError:
             raise ValueError("Provided string is not valid JSON")
     else:
         raise TypeError("Input must be of type dict or str")
-    
+
+
 def graphQLRequest(url: str, headers: dict, appkey_value: str, arguments: dict, verbose: bool):
     try:
         arguments = ensure_dict(arguments)
@@ -35,8 +38,8 @@ def graphQLRequest(url: str, headers: dict, appkey_value: str, arguments: dict, 
         if params:
             if verbose:
                 print_debug(f"params={params}")
-            response = client.execute(graphQuery, variable_values=params)                     
-        else: 
+            response = client.execute(graphQuery, variable_values=params)
+        else:
             response = client.execute(graphQuery)
         return json.dumps(response)
     except Exception as e:

--- a/src/slashgpt/function/network.py
+++ b/src/slashgpt/function/network.py
@@ -31,7 +31,13 @@ def graphQLRequest(url: str, headers: dict, appkey_value: str, arguments: dict, 
         client = Client(transport=transport)
         query = arguments.get("query")
         graphQuery = gql(f"query {query}")
-        response = client.execute(graphQuery)
+        params = arguments.get("variables")
+        if params:
+            if verbose:
+                print_debug(f"params={params}")
+            response = client.execute(graphQuery, variable_values=params)                     
+        else: 
+            response = client.execute(graphQuery)
         return json.dumps(response)
     except Exception as e:
         return str(e)

--- a/src/slashgpt/function/network.py
+++ b/src/slashgpt/function/network.py
@@ -1,15 +1,28 @@
 import json
 import urllib.parse
-
+import re
 import requests
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
 from slashgpt.utils.print import print_debug, print_error
 
-
+def ensure_dict(input_data):
+    if isinstance(input_data, dict):
+        return input_data
+    elif isinstance(input_data, str):
+        try:
+            #remove unnecessary \n from GPT
+            input_mod = re.sub(r"\n",'',input_data)
+            return json.loads(input_mod)
+        except json.JSONDecodeError:
+            raise ValueError("Provided string is not valid JSON")
+    else:
+        raise TypeError("Input must be of type dict or str")
+    
 def graphQLRequest(url: str, headers: dict, appkey_value: str, arguments: dict, verbose: bool):
     try:
+        arguments = ensure_dict(arguments)
         appkey = {"appkey": appkey_value}
         headers = {key: value.format(**arguments, **appkey) for key, value in headers.items()}
         if verbose:


### PR DESCRIPTION
1.  GPTからの応答で下記のように \n が余計に入っていると、jsonとしてのparseに失敗することがある。複雑なGraphQLだと度々発生していたので　回避策として\nを削ってからparse し直すコードを追加

```
Function call_graphQL: Failed to load arguments as json
{
  "name": "call_graphQL",
  "arguments": "{\n  \"query\": \"query {\n    repository(owner: \\\"snakajima\\\", name: \\\"SlashGPT\\\") {\n      ref(qualifiedName: \\\"main\\\") {\n        target {\n          ... on Commit {\n            history(since: \\\"2023-09-01T00:00:00Z\\\") {\n              totalCount\n              nodes {\n                author {\n                  user {\n                    login\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\"\n}"
}
```
function_call.py での修正も考えたが影響が大きいので　graphQLRequest　のなかに修正をとどめた

2.  またGPTからの応答でgraphQL のvariables を使用したフォーマットで返ってくることもあるので、対応した

```json:variables 
{
  "name": "call_graphQL",
  "arguments": "{\n  \"query\": \"query($owner: String!, $repo: String!, $since: GitTimestamp!) {\\n  repository(owner: $owner, name: $repo) {\\n    defaultBranchRef {\\n      target {\\n        ... on Commit {\\n          history(since: $since) {\\n            totalCount\\n            nodes {\\n              author {\\n                user {\\n                  login\\n                }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"owner\": \"snakajima\",\n    \"repo\": \"SlashGPT\",\n    \"since\": \"2023-09-01T00:00:00Z\"\n  }\n}"
}
```

上記修正後、 /spacex /gitm でも問題なく動作することを確認
