### PR TITLE
Extend openai_gpt Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Here are the design goals:
 5. It enables broker agent (or dispatcher), which routes user's message to an appropriate agent.
 6. It is able to run generated Python code like Code Interpreter (see "code" agent).
 
-> [!NOTE]  
-> If you want to try it out immediately, please try the Google Google Colaboratory version.  
+> [!NOTE]
+> If you want to try it out immediately, please try the Google Google Colaboratory version.
 
 <a href="https://colab.research.google.com/github/snakajima/SlashGPT/blob/main/notebooks/SlashGPT_on_GoogleColab.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab">
@@ -38,7 +38,7 @@ Then run SlashGPT
 
 ## Initialization for developer
 
-1. Install the required packages: 
+1. Install the required packages:
 
     `pip install -r requirements.txt`
 
@@ -76,10 +76,10 @@ Then run SlashGPT
 
 ## Outputs
 
-1. Each conversation will be store as a json file under the "output/{context}" folder, 
+1. Each conversation will be store as a json file under the "output/{context}" folder,
 where the context is "GTP" for general chat, and the app id for a specialized chat.
 
-2. Please notice that the "output" folder is ignored by git. 
+2. Please notice that the "output" folder is ignored by git.
 
 3. Code Interpreter agents will generate Jupyter notebook in "output/notebooks" folder.
 
@@ -124,6 +124,9 @@ Create a new manifest file, {agent_name}.json in "manifests" folder with followi
 - *intro* (array of strings, optional): Introduction statements (will be randomly selected)
 - *model* (string, optional): LLM model (such as "gpt-4-613", the default is "gpt-3-turbo")
 - *temperature* (number, optional): Temperature (the default is 0.7)
+- *stream* (boolean, optional): Enable LLM output streaming (not yet implemented)
+- *logprobs* (number, optional): Number of "next probable tokens" + associated log probabilities to return alongside the output
+- *num_completions* (number, optional): Number of different completions to request from the model per prompt
 - *list* (array of string, optional): {random} will put one of them randomly into the prompt
 - *embeddings* (object, optional):
   - *name* (string, optional): index name of the embedding vector database
@@ -138,13 +141,13 @@ Name of that file becomes the slash command. (the slash command of "foo.json" is
 
 It defines template-based function implementations (including mockups), alternative to writing Python code using the "module" property.
 
-It supports four different methods. 
+It supports four different methods.
 
 ### 1. Formatted string.
 
-Use this method to develop the front-end of a system before the backend become ready. 
+Use this method to develop the front-end of a system before the backend become ready.
 
-- *message* (format string, required): chat message to be added 
+- *message* (format string, required): chat message to be added
 - *manifest* (format string, optional): manifest file name to be loaded for chained action
 
 Here is an example (home2).

--- a/src/slashgpt/llms/engine/openai_gpt.py
+++ b/src/slashgpt/llms/engine/openai_gpt.py
@@ -2,7 +2,6 @@ import sys
 from typing import List
 
 import openai
-import tiktoken  # for counting tokens
 
 from slashgpt.function.function_call import FunctionCall
 from slashgpt.llms.engine.base import LLMEngineBase
@@ -18,12 +17,23 @@ class LLMEngineOpenAIGPT(LLMEngineBase):
             print_error("OPENAI_API_KEY environment variable is missing from .env")
             sys.exit()
         openai.api_key = key
+
+        # Override default openai endpoint for custom-hosted models
+        api_base = llm_model.get_api_base()
+        if api_base:
+            openai.api_base = api_base
+
         return
 
     def chat_completion(self, messages: List[dict], manifest: Manifest, verbose: bool):
+
+        model_name = self.llm_model.name()
         temperature = manifest.temperature()
         functions = manifest.functions()
-        model_name = self.llm_model.name()
+        stream = manifest.stream()
+        logprobs = manifest.logprobs()
+        num_completions = manifest.num_completions()
+
         if functions:
             response = openai.ChatCompletion.create(
                 model=model_name,
@@ -32,7 +42,15 @@ class LLMEngineOpenAIGPT(LLMEngineBase):
                 temperature=temperature,
             )
         else:
-            response = openai.ChatCompletion.create(model=model_name, messages=messages, temperature=temperature)
+            response = openai.ChatCompletion.create(
+                model=model_name,
+                messages=messages,
+                temperature=temperature,
+                stream=stream,
+                logprobs=logprobs,
+                n=num_completions
+            )
+
         if verbose:
             print_debug(f"model={response['model']}")
             print_debug(f"usage={response['usage']}")
@@ -45,8 +63,3 @@ class LLMEngineOpenAIGPT(LLMEngineBase):
             function_call = self._extract_function_call(messages[-1], manifest, res, True)
 
         return (role, res, function_call)
-
-    def num_tokens(self, text: str):
-        model_name = self.llm_model.name()
-        encoding = tiktoken.encoding_for_model(model_name)
-        return len(encoding.encode(text))

--- a/src/slashgpt/llms/model.py
+++ b/src/slashgpt/llms/model.py
@@ -26,6 +26,7 @@ class LlmModel:
             engine_name (str): name of the engine (e.g, openai-gpt')
             model_name (str): specific model name (e.g, 'gpt-3.5-turbo-0613')
             api_key (str): name of the env. variable which holds a secret key (e.g, 'OPENAI_API_KEY')
+            api_base (str): endpoint url hosted models compatible with OpenAI chat completions API
             max_token (str): maximum token length (e.g, 4096)
             default (boolean, optional): True if this is the default model
         """
@@ -60,6 +61,10 @@ class LlmModel:
         """Returns the api key specified in the environment"""
         return os.getenv(self.get("api_key"), "")
 
+    def get_api_base(self):
+        """Returns the openai api base url"""
+        return self.get("api_base")
+
     def __get_engine(self, llm_engine_configs: dict):
         class_data = llm_engine_configs.get(self.engine_name())
 
@@ -84,6 +89,3 @@ class LlmModel:
             verbose (bool): True if it's in verbose mode.
         """
         return self.engine.chat_completion(messages, manifest, verbose)
-
-    def num_tokens(self, text: str):
-        return self.engine.num_tokens(text)

--- a/src/slashgpt/manifest.py
+++ b/src/slashgpt/manifest.py
@@ -49,6 +49,18 @@ class Manifest:
             return float(self.get("temperature"))
         return 0.7
 
+    def stream(self):
+        """Returns a boolean value indicating if the LLM should stream its output back to the user (bool)"""
+        return self.get("stream") or False
+
+    def logprobs(self):
+        """Returns the number of tokens for whichthe LLM will display log probabilities, with a max of 5 (int)"""
+        return self.get("logprobs") or None
+
+    def num_completions(self):
+        """Returns the number of desired LLM completions per prompt (int)"""
+        return self.get("num_completions") or 1
+
     def model(self):
         """Returns the specified LLM model (str or dict)"""
         return self.get("model")


### PR DESCRIPTION
* Allows manifests to specify an `api_base`, which will then update the `openai.api_base` variable in the LLM engine, allowing for OpenAI API calls to arbitrary endpoints while using the `openai_gpt` engine

* Sets some new defaults in `manifest.py` for common completions API parameters
    * `stream` - whether to enable streaming or not (NOTE: streaming support not currently implemented downstream)
    * `logprobs` - how many of the "next probable tokens" + associated log probabilities to return alongside the output
    * `num_completions` - how many different completions to request from the model for the given prompt
    
These changes allow for integration with TNE-hosted LM daemons using the manifest file only