### PR TITLE
More engine test

### DIFF
--- a/tests/llm_engine/test_engine.py
+++ b/tests/llm_engine/test_engine.py
@@ -49,10 +49,6 @@ mock_model = {
             }
 
 class Test:
-    def process_event(self, callback_type, data):
-        if callback_type == "bot":
-            self.res = data  # record the output from the LLM
-
     def test_simple(self):
         manifest = {
             "model": mock_model,
@@ -60,20 +56,20 @@ class Test:
         }
         session = ChatSession(config, manifest=manifest)
         session.append_user_question("Hi")
-        session.call_loop(self.process_event)
-        assert self.res == "Hello World"
+        (message, _function_call) = session.call_llm()
+        assert message == "Hello World"
         session.append_user_question("Bye")
-        session.call_loop(self.process_event)
-        assert self.res == "Sayonara"
+        (message, _function_call) = session.call_llm()
+        assert message == "Sayonara"
         session.append_user_question("Repeat this message.")
-        session.call_loop(self.process_event)
-        assert self.res == "Repeat this message."
+        (message, _function_call) = session.call_llm()
+        assert message == "Repeat this message."
         session.append_user_question("prompt")
-        session.call_loop(self.process_event)
-        assert self.res == manifest.get("prompt")
+        (message, _function_call) = session.call_llm()
+        assert message == manifest.get("prompt")
         session.append_user_question("model")
-        session.call_loop(self.process_event)
-        assert self.res == "mock_model"
+        (message, _function_call) = session.call_llm()
+        assert message == "mock_model"
 
     def test_memory(self):
         manifest = {
@@ -83,5 +79,5 @@ class Test:
         memory = {"name": "Joe Smith"}
         session = ChatSession(config, manifest=manifest, memory=memory)
         session.append_user_question("prompt")
-        session.call_loop(self.process_event)
-        assert self.res == manifest.get("prompt").format(memory=json.dumps(memory))
+        (message, _function_call) = session.call_llm()
+        assert message == manifest.get("prompt").format(memory=json.dumps(memory))

--- a/tests/llm_engine/test_engine.py
+++ b/tests/llm_engine/test_engine.py
@@ -46,10 +46,11 @@ my_llm_engine_configs = {
 config = ChatConfig(current_dir, llm_engine_configs=my_llm_engine_configs)
 
 mock_model = {
-                "engine_name": "mock_engine",
-                "model_name": "mock_model",
-                "x_custom": "mock_value",
-            }
+    "engine_name": "mock_engine",
+    "model_name": "mock_model",
+    "x_custom": "mock_value",
+}
+
 
 class Test:
     def test_simple(self):
@@ -80,7 +81,7 @@ class Test:
     def test_memory(self):
         manifest = {
             "model": mock_model,
-            "prompt":  "This is prompt {memory}",
+            "prompt": "This is prompt {memory}",
         }
         memory = {"name": "Joe Smith"}
         session = ChatSession(config, manifest=manifest, memory=memory)

--- a/tests/llm_engine/test_engine.py
+++ b/tests/llm_engine/test_engine.py
@@ -35,17 +35,20 @@ class MockLlmEngine(LLMEngineBase):
                 res = messages[0].get("content") or ""
             elif last_message == "model":
                 res = self.llm_model.name()
+            elif last_message == "custom":
+                res = self.llm_model.get("x_custom")
         return (role, res, function_call)
 
 
 my_llm_engine_configs = {
-    "my_engine": MockLlmEngine,
+    "mock_engine": MockLlmEngine,
 }
 config = ChatConfig(current_dir, llm_engine_configs=my_llm_engine_configs)
 
 mock_model = {
-                "engine_name": "my_engine",
+                "engine_name": "mock_engine",
                 "model_name": "mock_model",
+                "x_custom": "mock_value",
             }
 
 class Test:
@@ -70,6 +73,9 @@ class Test:
         session.append_user_question("model")
         (message, _function_call) = session.call_llm()
         assert message == "mock_model"
+        session.append_user_question("custom")
+        (message, _function_call) = session.call_llm()
+        assert message == "mock_value"
 
     def test_memory(self):
         manifest = {


### PR DESCRIPTION
1. Use session.call_llm instead of call_loop to simplify the process
2. Pass the custom llm_model as a part of manifest.
3. Test case for model name, and custom key (in the llm_model).