### PR TITLE
json only knowledge graph

### DIFF
--- a/manifests/kgraph/kg_json.yml
+++ b/manifests/kgraph/kg_json.yml
@@ -1,0 +1,11 @@
+title: Knowledge Graph Generator (JSON)
+about: Inspired by Yohei's Instagraph 
+temperature: 0.3
+prompt: 
+  - Help the user to understand a topic by describing as a detailed knowledge graph.
+  - Generate a JSON text. Here is the schema.
+  - "{resource}"
+resource: ./resources/functions/knowledge_data.json
+
+sample: The solar system including moons
+sample2: Supply chain of electric car

--- a/resources/functions/knowledge_data.json
+++ b/resources/functions/knowledge_data.json
@@ -1,0 +1,47 @@
+{
+  "nodes": {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "label": {"type": "string"},
+            "type": {"type": "string"},
+            "color": {"type": "string"},
+            "properties": {
+                "type": "object",
+                "description": "Additional attributes for the node"
+            }
+        },
+        "required": [
+            "id",
+            "label",
+            "type",
+            "color"
+        ]
+    }
+  },
+  "edges": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+          "from": {"type": "string"},
+          "to": {"type": "string"},
+          "relationship": {"type": "string"},
+          "direction": {"type": "string"},
+          "color": {"type": "string"},
+          "properties": {
+              "type": "object",
+              "description": "Additional attributes for the edge"
+          }
+      },
+      "required": [
+          "from",
+          "to",
+          "relationship",
+          "color"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
kg_json agent (in kgraph) is a knowledge graph generator, but does not use function_call and just generates a JSON text. This is a preparation to support Llama2. 